### PR TITLE
Resolve warning and errors found by latest Google Closure Compiler

### DIFF
--- a/source/npf/pages/request.js
+++ b/source/npf/pages/request.js
@@ -39,7 +39,7 @@ npf.pages.Request = function(uri, opt_route, opt_name, opt_options) {
  * @return {npf.pages.Request}
  */
 npf.pages.Request.prototype.clone = function() {
-  var options = options ? goog.object.clone(this.options) : null;
+  var options = this.options ? goog.object.clone(this.options) : null;
 
   return new npf.pages.Request(
     this.uri.clone(), this.route, this.name, options);

--- a/source/npf/user_agent/css.js
+++ b/source/npf/user_agent/css.js
@@ -1257,7 +1257,7 @@ npf.userAgent.css.isNthChildSupported = function() {
 
     npf.userAgent.css.nthChild_ =
       npf.userAgent.utils.testStyles(styles, function(elem) {
-        var elems = elem.getElementsByTagName(goog.dom.TagName.DIV);
+        var elems = goog.dom.getElementsByTagName(goog.dom.TagName.DIV, elem);
         /** @type {boolean} */
         var supports = true;
 


### PR DESCRIPTION
Resolved following issues:

1. Seems like mistyping:
```
npf/source/npf/pages/request.js:42: WARNING - Variable referenced before declaration: options
  var options = options ? goog.object.clone(this.options) : null;
                ^
```
2. Google Closure wants {string} for `nativeElement.getElementsByTagName`, but {enum} for `goog.dom.getElementsByTagName`:
```
npf/source/npf/user_agent/css.js:1260: ERROR - actual parameter 1 of Element.prototype.getElementsByTagName does not match formal parameter
found   : goog.dom.TagName<HTMLDivElement>
required: string
        var elems = elem.getElementsByTagName(goog.dom.TagName.DIV);
                                              ^
```